### PR TITLE
fix i18n on islands

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,14 +1,10 @@
-import { useContext } from 'preact/hooks';
-
 import Dialog from './Dialog.tsx';
 
 import IconLogout from 'icons/logout.tsx';
 
-import { i18n, i18nContext } from '../utils/i18n.ts';
+import { i18n } from '../utils/i18n.ts';
 
 export default ({ id, avatar }: { id: string; avatar?: string }) => {
-  const locale = useContext(i18nContext);
-
   return (
     <>
       <img
@@ -22,7 +18,7 @@ export default ({ id, avatar }: { id: string; avatar?: string }) => {
       <Dialog name={'logout'} class={'user-dialog'}>
         <form method={'post'} action={'/api/logout'}>
           <button type={'submit'}>
-            {i18n('logout', locale)}
+            {i18n('logout')}
             <IconLogout />
           </button>
         </form>

--- a/src/components/Characters.tsx
+++ b/src/components/Characters.tsx
@@ -1,6 +1,6 @@
 import '#filter-boolean';
 
-import { useCallback, useContext, useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 
 import { type Signal, useSignal } from '@preact/signals';
 
@@ -27,7 +27,7 @@ import IconAdd from 'icons/circle-plus.tsx';
 import IconRemove from 'icons/circle-minus.tsx';
 import IconReset from 'icons/circle-x.tsx';
 
-import { i18n, i18nContext } from '../utils/i18n.ts';
+import { i18n } from '../utils/i18n.ts';
 
 import { type Character, CharacterRole, type Media } from '../utils/types.ts';
 
@@ -40,8 +40,6 @@ export default (
     visible: boolean;
   },
 ) => {
-  const locale = useContext(i18nContext);
-
   const [, updateState] = useState({});
 
   // used to force the entire component to redrew
@@ -69,10 +67,10 @@ export default (
           ? (
             <div class={'item'}>
               <div />
-              <i>{i18n('name', locale)}</i>
-              <i>{i18n('primaryMedia', locale)}</i>
-              <i>{i18n('role', locale)}</i>
-              <i>{i18n('rating', locale)}</i>
+              <i>{i18n('name')}</i>
+              <i>{i18n('primaryMedia')}</i>
+              <i>{i18n('role')}</i>
+              <i>{i18n('rating')}</i>
             </div>
           )
           : undefined}
@@ -141,7 +139,7 @@ export default (
                   signal.value.id === id
                 );
 
-                if (i > -1 && window.confirm(i18n('deleteCharacter', locale))) {
+                if (i > -1 && window.confirm(i18n('deleteCharacter'))) {
                   characters.value.splice(i, 1);
                   forceUpdate();
                   requestAnimationFrame(() => hideDialog('characters'));
@@ -163,7 +161,7 @@ export default (
           <TextInput
             required
             pattern='.{1,128}'
-            label={i18n('name', locale)}
+            label={i18n('name')}
             value={signal.value.name.english ?? ''}
             onInput={(value) => signal.value.name.english = value}
             key={`${signal.value.id}-title`}
@@ -171,7 +169,7 @@ export default (
 
           <div class={'group'}>
             <Select
-              label={i18n('primaryMedia', locale)}
+              label={i18n('primaryMedia')}
               data-warning={!signal.value.media?.length}
               defaultValue={signal.value.media?.[0]?.mediaId}
               list={media.value.reduce((acc, media) => {
@@ -190,7 +188,7 @@ export default (
               ? (
                 <Select
                   required
-                  label={i18n('role', locale)}
+                  label={i18n('role')}
                   list={CharacterRole}
                   // deno-lint-ignore no-non-null-assertion
                   defaultValue={signal.value.media![0].role}
@@ -207,7 +205,7 @@ export default (
           {!signal.value.media?.length
             ? (
               <Notice type={'warn'}>
-                {i18n('primaryMediaNotice', locale)}
+                {i18n('primaryMediaNotice')}
               </Notice>
             )
             : undefined}
@@ -215,11 +213,11 @@ export default (
           <div class={'other'}>
             <div class={'rating'}>
               <label class={'label'}>
-                {i18n('rating', locale)}
+                {i18n('rating')}
                 {': '}
                 {typeof signal.value.popularity === 'number'
-                  ? i18n('basedOnIndividual', locale)
-                  : i18n('basedOnMedia', locale)}
+                  ? i18n('basedOnIndividual')
+                  : i18n('basedOnMedia')}
               </label>
               <div>
                 <div>
@@ -266,16 +264,16 @@ export default (
 
             <div class={'group'}>
               <TextInput
-                label={i18n('age', locale)}
-                placeholder={i18n('placeholderAge', locale)}
+                label={i18n('age')}
+                placeholder={i18n('placeholderAge')}
                 value={signal.value.age ?? ''}
                 onInput={(value) => signal.value.age = value || undefined}
                 key={`${signal.value.id}-age`}
               />
 
               <TextInput
-                label={i18n('gender', locale)}
-                placeholder={i18n('placeholderGender', locale)}
+                label={i18n('gender')}
+                placeholder={i18n('placeholderGender')}
                 value={signal.value.gender ?? ''}
                 onInput={(value) => signal.value.gender = value || undefined}
                 key={`${signal.value.id}-gender`}
@@ -285,16 +283,16 @@ export default (
             <TextInput
               multiline
               pattern='.{1,2048}'
-              label={i18n('description', locale)}
-              placeholder={i18n('placeholderCharDescription', locale)}
+              label={i18n('description')}
+              placeholder={i18n('placeholderCharDescription')}
               value={signal.value.description}
               onInput={(value) => signal.value.description = value || undefined}
               key={`${signal.value.id}-description`}
             />
 
             <div class={'group-colum'}>
-              <label class={'label'}>{i18n('aliases', locale)}</label>
-              <label class={'hint'}>{i18n('aliasesHint', locale)}</label>
+              <label class={'label'}>{i18n('aliases')}</label>
+              <label class={'hint'}>{i18n('aliasesHint')}</label>
               <div class={'aliases'}>
                 {signal.value.name.alternative?.map((alias, i) => (
                   <div class={'alias'} key={i}>
@@ -344,8 +342,8 @@ export default (
             </div>
 
             <div class={'group-colum'}>
-              <label class={'label'}>{i18n('links', locale)}</label>
-              <Notice type={'info'}>{i18n('linksNotice', locale)}</Notice>
+              <label class={'label'}>{i18n('links')}</label>
+              <Notice type={'info'}>{i18n('linksNotice')}</Notice>
               <div class={'links'}>
                 {signal.value.externalLinks?.map((link, i) => (
                   <div class={'group'}>

--- a/src/components/Conflicts.tsx
+++ b/src/components/Conflicts.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import { type Signal, useSignal } from '@preact/signals';
 
@@ -8,7 +8,7 @@ import IconTrash from 'icons/trash.tsx';
 
 import { gql, request } from '../utils/graphql.ts';
 
-import { i18n, i18nContext } from '../utils/i18n.ts';
+import { i18n } from '../utils/i18n.ts';
 
 const getAnilistIds = (ids: string[]) => {
   const anilistIds: number[] = [];
@@ -69,8 +69,6 @@ export default ({ conflicts, visible }: {
   conflicts: Signal<string[]>;
   visible: boolean;
 }) => {
-  const locale = useContext(i18nContext);
-
   const [, updateState] = useState({});
 
   // used to force the entire component to redrew
@@ -129,7 +127,7 @@ export default ({ conflicts, visible }: {
       <div class={'search'}>
         <input
           type={'text'}
-          placeholder={i18n('search', locale)}
+          placeholder={i18n('search')}
           onFocus={() => focused.value = true}
           onInput={(event) => {
             search.value = (event.target as HTMLInputElement).value;
@@ -190,7 +188,7 @@ export default ({ conflicts, visible }: {
 
       <i />
 
-      <Notice type={'info'}>{i18n('conflictsNotice', locale)}</Notice>
+      <Notice type={'info'}>{i18n('conflictsNotice')}</Notice>
 
       <div class='group'>
         {conflicts.value

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,3 @@
-import { useContext } from 'preact/hooks';
-
 import Card from './Card.tsx';
 import Avatar from './Avatar.tsx';
 
@@ -11,7 +9,7 @@ import IconLink from 'icons/link.tsx';
 import IconPlus from 'icons/plus.tsx';
 import IconClipboard from 'icons/clipboard-text.tsx';
 
-import { i18n, i18nContext } from '../utils/i18n.ts';
+import { i18n } from '../utils/i18n.ts';
 
 import type { Pack, User } from '../utils/types.ts';
 
@@ -30,8 +28,6 @@ export default ({ data, url, params }: PageProps<DashboardData>) => {
   const { searchParams } = url;
 
   const packId = params.id;
-
-  const locale = useContext(i18nContext);
 
   // deno-lint-ignore no-non-null-assertion
   const user = data.user!;
@@ -73,7 +69,7 @@ export default ({ data, url, params }: PageProps<DashboardData>) => {
           <Dialog name={'success'} class={'dialog-normal'} visible={true}>
             <div>
               <p>
-                {i18n('successTitle', locale)}
+                {i18n('successTitle')}
               </p>
               <div
                 class={'install-info'}
@@ -83,12 +79,12 @@ export default ({ data, url, params }: PageProps<DashboardData>) => {
                 <IconClipboard />
               </div>
               <Notice type={'info'}>
-                {i18n('successYouNeed', locale)}
-                <strong>{i18n('successManageServer', locale)}</strong>
-                {i18n('successPermissionToInstall', locale)}
+                {i18n('successYouNeed')}
+                <strong>{i18n('successManageServer')}</strong>
+                {i18n('successPermissionToInstall')}
               </Notice>
               <button data-dialog-cancel={'success'}>
-                {i18n('okay', locale)}
+                {i18n('okay')}
               </button>
             </div>
           </Dialog>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,18 +1,14 @@
-import { useContext } from 'preact/hooks';
-
 import DiscordIcon from 'icons/brand-discord-filled.tsx';
 
-import { i18n, i18nContext } from '../utils/i18n.ts';
+import { i18n } from '../utils/i18n.ts';
 
 export default () => {
-  const locale = useContext(i18nContext);
-
   return (
     <form class={'login-wrapper'} method={'post'} action={'/api/login'}>
       <div class={'login-container'}>
         <img src={'/icon.png'} />
         <button type={'submit'}>
-          {i18n('loginWithDiscord', locale)}
+          {i18n('loginWithDiscord')}
           <DiscordIcon />
         </button>
       </div>

--- a/src/components/Maintainers.tsx
+++ b/src/components/Maintainers.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from 'preact/hooks';
+import { useCallback, useEffect, useState } from 'preact/hooks';
 
 import { type Signal, useSignal } from '@preact/signals';
 
@@ -7,7 +7,7 @@ import Notice from './Notice.tsx';
 import IconTrash from 'icons/trash.tsx';
 import IconCrown from 'icons/crown.tsx';
 
-import { i18n, i18nContext } from '../utils/i18n.ts';
+import { i18n } from '../utils/i18n.ts';
 
 import type { User } from '../utils/types.ts';
 
@@ -49,8 +49,6 @@ export default ({ owner, maintainers, visible }: {
   maintainers: Signal<string[]>;
   visible: boolean;
 }) => {
-  const locale = useContext(i18nContext);
-
   const [, updateState] = useState({});
 
   // used to force the entire component to redrew
@@ -82,7 +80,7 @@ export default ({ owner, maintainers, visible }: {
 
   return (
     <div style={{ display: visible ? '' : 'none' }} class={'maintainers'}>
-      <label>{i18n('userId', locale)}</label>
+      <label>{i18n('userId')}</label>
 
       <input
         type={'text'}
@@ -102,12 +100,12 @@ export default ({ owner, maintainers, visible }: {
           forceUpdate();
         }}
       >
-        {i18n('addNew', locale)}
+        {i18n('addNew')}
       </button>
 
       <i />
 
-      <Notice type={'info'}>{i18n('maintainersNotice', locale)}</Notice>
+      <Notice type={'info'}>{i18n('maintainersNotice')}</Notice>
 
       <div class='group'>
         <Profile id={owner} user={data[owner]} removable={false} />

--- a/src/components/Manage.tsx
+++ b/src/components/Manage.tsx
@@ -1,5 +1,3 @@
-import { useContext } from 'preact/hooks';
-
 import { useSignal } from '@preact/signals';
 
 import { serialize } from 'bson';
@@ -27,7 +25,7 @@ import IconTable from 'icons/table.tsx';
 import nanoid from '../utils/nanoid.ts';
 import compact from '../utils/compact.ts';
 
-import { i18n, i18nContext } from '../utils/i18n.ts';
+import { i18n, locale } from '../utils/i18n.ts';
 
 import type { Data } from '../api/publish.ts';
 
@@ -44,8 +42,6 @@ export default (props: {
   pack?: Pack;
   new?: boolean;
 }) => {
-  const locale = useContext(i18nContext);
-
   const servers = compact(props.pack?.servers ?? 0);
 
   const pack: Readonly<Pack['manifest']> = props.pack?.manifest
@@ -225,7 +221,7 @@ export default (props: {
         action={'back'}
       >
         {/* this component require client-side javascript */}
-        <noscript>{i18n('noScript', locale)}</noscript>
+        <noscript>{i18n('noScript')}</noscript>
 
         <Dialog name={'extra'} class={'dialog-normal'}>
           <div class={'metadata'}>
@@ -234,7 +230,7 @@ export default (props: {
             {!props.new
               ? (
                 <>
-                  <label>{i18n('packServers', locale, servers)}</label>
+                  <label>{i18n('packServers', servers)}</label>
 
                   <div
                     class={'install-info'}
@@ -250,46 +246,46 @@ export default (props: {
             {privacy.value
               ? (
                 <>
-                  <Notice type={'info'}>{i18n('privateNotice', locale)}</Notice>
+                  <Notice type={'info'}>{i18n('privateNotice')}</Notice>
                   <button onClick={() => privacy.value = false}>
-                    {i18n('setPublic', locale)}
+                    {i18n('setPublic')}
                   </button>
                 </>
               )
               : (
                 <>
                   <button onClick={() => privacy.value = true}>
-                    {i18n('setPrivate', locale)}
+                    {i18n('setPrivate')}
                   </button>
                 </>
               )}
 
             <TextInput
               value={author}
-              label={i18n('packAuthor', locale)}
-              placeholder={i18n('placeholderPackAuthor', locale)}
+              label={i18n('packAuthor')}
+              placeholder={i18n('placeholderPackAuthor')}
               onInput={(value) => author.value = value}
             />
 
             <TextInput
               multiline
               value={description}
-              label={i18n('packDescription', locale)}
-              placeholder={i18n('placeholderPackDescription', locale)}
+              label={i18n('packDescription')}
+              placeholder={i18n('placeholderPackDescription')}
               onInput={(value) => description.value = value}
             />
 
             <TextInput
               value={webhookUrl}
-              label={i18n('packWebhookUrl', locale)}
-              hint={i18n('packWebhookUrlHint', locale)}
+              label={i18n('packWebhookUrl')}
+              hint={i18n('packWebhookUrlHint')}
               pattern={'https:\/\/discord\.com\/api\/webhooks\/[0-9]{18,19}\/.+'}
               placeholder={'https://discord.com/api/webhooks/185033133521895424/AAabbb'}
               onInput={(value) => webhookUrl.value = value}
             />
 
             <button onClick={onExport} class={'export'}>
-              {i18n('export', locale)}
+              {i18n('export')}
             </button>
           </div>
         </Dialog>
@@ -307,7 +303,7 @@ export default (props: {
               type={'text'}
               value={title}
               pattern='.{3,128}'
-              placeholder={i18n('packTitle', locale)}
+              placeholder={i18n('packTitle')}
               onInput={(
                 ev,
               ) => (title.value = (ev.target as HTMLInputElement).value)}
@@ -315,7 +311,7 @@ export default (props: {
 
             <div class={'buttons'}>
               <button disabled={loading} onClick={onPublish}>
-                {props.new ? i18n('publish', locale) : i18n('save', locale)}
+                {props.new ? i18n('publish') : i18n('save')}
               </button>
 
               <button
@@ -332,7 +328,7 @@ export default (props: {
                   characterSignal.value = item;
                 }}
               >
-                {i18n('addNewCharacter', locale)}
+                {i18n('addNewCharacter')}
               </button>
 
               <button
@@ -350,7 +346,7 @@ export default (props: {
                   mediaSignal.value = item;
                 }}
               >
-                {i18n('addNewMedia', locale)}
+                {i18n('addNewMedia')}
               </button>
             </div>
 
@@ -368,7 +364,7 @@ export default (props: {
           </div>
 
           <div class={'tabs'}>
-            {(i18n('tabs', locale) as unknown as string[])
+            {(i18n('tabs') as unknown as string[])
               .map((s, i) => (
                 <div
                   key={i}

--- a/src/components/Media.tsx
+++ b/src/components/Media.tsx
@@ -1,6 +1,6 @@
 import '#filter-boolean';
 
-import { useCallback, useContext, useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 
 import { type Signal, useSignal } from '@preact/signals';
 
@@ -22,7 +22,7 @@ import IconApply from 'icons/check.tsx';
 
 import comma from '../utils/comma.ts';
 
-import { i18n, i18nContext } from '../utils/i18n.ts';
+import { i18n } from '../utils/i18n.ts';
 
 import {
   Character,
@@ -41,8 +41,6 @@ export default (
     visible: boolean;
   },
 ) => {
-  const locale = useContext(i18nContext);
-
   const [, updateState] = useState({});
 
   // used to force the entire component to redrew
@@ -57,8 +55,8 @@ export default (
           ? (
             <div class={'item'}>
               <div />
-              <i>{i18n('title', locale)}</i>
-              <i>{i18n('popularity', locale)}</i>
+              <i>{i18n('title')}</i>
+              <i>{i18n('popularity')}</i>
             </div>
           )
           : undefined}
@@ -106,7 +104,7 @@ export default (
                   signal.value.id === id
                 );
 
-                if (i > -1 && window.confirm(i18n('deleteMedia', locale))) {
+                if (i > -1 && window.confirm(i18n('deleteMedia'))) {
                   media.value.splice(i, 1);
                   forceUpdate();
                   requestAnimationFrame(() => hideDialog('media'));
@@ -128,7 +126,7 @@ export default (
           <Select
             required
             list={MediaType}
-            label={i18n('type', locale)}
+            label={i18n('type')}
             defaultValue={signal.value.type}
             onChange={(t: MediaType) => signal.value.type = t}
           />
@@ -136,7 +134,7 @@ export default (
           <TextInput
             required
             pattern='.{1,128}'
-            label={i18n('title', locale)}
+            label={i18n('title')}
             value={signal.value.title.english ?? ''}
             onInput={(value) => signal.value.title.english = value}
             key={`${signal.value.id}-title`}
@@ -145,7 +143,7 @@ export default (
           <div class={'other'}>
             <Select
               list={MediaFormat}
-              label={i18n('format', locale)}
+              label={i18n('format')}
               defaultValue={signal.value.format}
               onChange={(f: MediaFormat) =>
                 // deno-lint-ignore no-explicit-any
@@ -156,9 +154,9 @@ export default (
               min={0}
               max={2147483647}
               type={'number'}
-              label={i18n('popularity', locale)}
+              label={i18n('popularity')}
               value={signal.value.popularity ?? 0}
-              hint={i18n('popularityHint', locale)}
+              hint={i18n('popularityHint')}
               onInput={(value) => signal.value.popularity = Number(value ?? 0)}
               key={`${signal.value.id}-popularity`}
             />
@@ -166,16 +164,16 @@ export default (
             <TextInput
               multiline
               pattern='.{1,2048}'
-              label={i18n('description', locale)}
-              placeholder={i18n('placeholderMediaDescription', locale)}
+              label={i18n('description')}
+              placeholder={i18n('placeholderMediaDescription')}
               value={signal.value.description}
               onInput={(value) => signal.value.description = value}
               key={`${signal.value.id}-description`}
             />
 
             <div class={'group-colum'}>
-              <label class={'label'}>{i18n('aliases', locale)}</label>
-              <label class={'hint'}>{i18n('aliasesHint', locale)}</label>
+              <label class={'label'}>{i18n('aliases')}</label>
+              <label class={'hint'}>{i18n('aliasesHint')}</label>
               <div class={'aliases'}>
                 {signal.value.title.alternative?.map((alias, i) => (
                   <div class={'alias'} key={i}>
@@ -225,7 +223,7 @@ export default (
             </div>
 
             <div class={'group-colum'}>
-              <label class={'label'}>{i18n('relations', locale)}</label>
+              <label class={'label'}>{i18n('relations')}</label>
               {/* <label class={'hint'}>{strings.aliasesHint}</label> */}
               <div class={'relations'}>
                 {media.value
@@ -243,7 +241,7 @@ export default (
                           {media.title.english}
                         </i>
                         <Select
-                          nullLabel={i18n('none', locale)}
+                          nullLabel={i18n('none')}
                           list={MediaRelation}
                           defaultValue={defaultValue > -1
                             // deno-lint-ignore no-non-null-assertion
@@ -286,8 +284,8 @@ export default (
             </div>
 
             <div class={'group-colum'}>
-              <label class={'label'}>{i18n('links', locale)}</label>
-              <Notice type={'info'}>{i18n('linksNotice', locale)}</Notice>
+              <label class={'label'}>{i18n('links')}</label>
+              <Notice type={'info'}>{i18n('linksNotice')}</Notice>
               <div class={'links'}>
                 {signal.value.externalLinks?.map((link, i) => (
                   <div class={'group'}>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,7 +8,7 @@ import Maintenance from './_503.tsx';
 
 import Dashboard, { type DashboardData } from '../components/Dashboard.tsx';
 
-import { i18nContext, pick } from '../utils/i18n.ts';
+import { i18nSSR } from '../utils/i18n.ts';
 
 import type { Pack, User } from '../utils/types.ts';
 
@@ -87,21 +87,16 @@ export const handler: Handlers = {
       return ctx.renderNotFound();
     }
 
-    return ctx.render({
-      ...data,
-      locale: pick(req.headers.get('Accept-Language') ?? ''),
-    });
+    i18nSSR(req.headers.get('Accept-Language') ?? '');
+
+    return ctx.render(data);
   },
 };
 
-export default (props: PageProps<DashboardData & { locale: string }>) => {
-  return (
-    <i18nContext.Provider value={props.data.locale}>
-      {props.data.maintenance
-        ? <Maintenance />
-        : props.data.user
-        ? <Dashboard {...props} />
-        : <Login />}
-    </i18nContext.Provider>
-  );
+export default (props: PageProps<DashboardData>) => {
+  if (props.data.maintenance) {
+    return <Maintenance />;
+  }
+
+  return props.data.user ? <Dashboard {...props} /> : <Login />;
 };


### PR DESCRIPTION
The Preact Context wasn't working as I imagined, it didn't send the value to client-side islands, and neither did signals. 

So as a workaround, we detect if the i18n code is running on the browser and use `navigator.languages` instead of depending on the server to set the locale for islands 